### PR TITLE
Refactor scheduling logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+all: build
+.PHONY: all
+
+SUBMODULES=
+
+FFI_PATH:=./extern/filecoin-ffi/
+FFI_DEPS:=.install-filcrypto
+FFI_DEPS:=$(addprefix $(FFI_PATH),$(FFI_DEPS))
+
+$(FFI_DEPS): .filecoin-build ;
+
+.filecoin-build: $(FFI_PATH)
+	$(MAKE) -C $(FFI_PATH) $(FFI_DEPS:$(FFI_PATH)%=%)
+	@touch $@
+
+.update-modules:
+	git submodule update --init --recursive
+	@touch $@
+
+test: .update-modules .filecoin-build
+	go test -v ./...
+.PHONY: test
+SUBMODULES+=test
+
+build: $(SUBMODULES)
+
+clean:
+	rm -f .filecoin-build
+	rm -f .update-modules

--- a/localworker.go
+++ b/localworker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/elastic/go-sysinfo"
 	"golang.org/x/xerrors"
@@ -195,6 +196,7 @@ func (l *LocalWorker) Info(context.Context) (storiface.WorkerInfo, error) {
 			MemPhysical: mem.Total,
 			MemSwap:     mem.VirtualTotal,
 			MemReserved: mem.VirtualUsed + mem.Total - mem.Available, // TODO: sub this process
+			CPUs:        uint64(runtime.NumCPU()),
 			GPUs:        gpus,
 		},
 	}, nil

--- a/localworker.go
+++ b/localworker.go
@@ -104,6 +104,15 @@ func (l *LocalWorker) AddPiece(ctx context.Context, sector abi.SectorID, epcs []
 	return sb.AddPiece(ctx, sector, epcs, sz, r)
 }
 
+func (l *LocalWorker) Fetch(ctx context.Context, sector abi.SectorID, fileType stores.SectorFileType, sealing bool) error {
+	_, done, err := (&localWorkerPathProvider{w: l}).AcquireSector(ctx, sector, fileType, stores.FTNone, sealing)
+	if err != nil {
+		return err
+	}
+	done()
+	return nil
+}
+
 func (l *LocalWorker) SealPreCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, pieces []abi.PieceInfo) (out storage2.PreCommit1Out, err error) {
 	sb, err := l.sb()
 	if err != nil {

--- a/manager.go
+++ b/manager.go
@@ -1,12 +1,10 @@
 package sectorstorage
 
 import (
-	"container/list"
 	"context"
 	"errors"
 	"io"
 	"net/http"
-	"sync"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -62,18 +60,9 @@ type Manager struct {
 	remoteHnd  *stores.FetchHandler
 	index      stores.SectorIndex
 
+	sched *scheduler
+
 	storage.Prover
-
-	workersLk  sync.Mutex
-	nextWorker WorkerID
-	workers    map[WorkerID]*workerHandle
-
-	newWorkers chan *workerHandle
-	schedule   chan *workerRequest
-	workerFree chan WorkerID
-	closing    chan struct{}
-
-	schedQueue *list.List // List[*workerRequest]
 }
 
 type SealerConfig struct {
@@ -107,20 +96,12 @@ func New(ctx context.Context, ls stores.LocalStorage, si stores.SectorIndex, cfg
 		remoteHnd:  &stores.FetchHandler{Local: lstor},
 		index:      si,
 
-		nextWorker: 0,
-		workers:    map[WorkerID]*workerHandle{},
-
-		newWorkers: make(chan *workerHandle),
-		schedule:   make(chan *workerRequest),
-		workerFree: make(chan WorkerID),
-		closing:    make(chan struct{}),
-
-		schedQueue: list.New(),
+		sched: newScheduler(cfg.SealProofType),
 
 		Prover: prover,
 	}
 
-	go m.runSched()
+	go m.sched.runSched()
 
 	localTasks := []sealtasks.TaskType{
 		sealtasks.TTAddPiece, sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTFetch,
@@ -170,7 +151,7 @@ func (m *Manager) AddWorker(ctx context.Context, w Worker) error {
 		return xerrors.Errorf("getting worker info: %w", err)
 	}
 
-	m.newWorkers <- &workerHandle{
+	m.sched.newWorkers <- &workerHandle{
 		w:    w,
 		info: info,
 	}
@@ -190,7 +171,7 @@ func (m *Manager) ReadPieceFromSealedSector(context.Context, abi.SectorID, ffiwr
 	panic("implement me")
 }
 
-func (m *Manager) getWorkersByPaths(task sealtasks.TaskType, inPaths []stores.StorageInfo) ([]WorkerID, map[WorkerID]stores.StorageInfo) {
+/*func (m *Manager) getWorkersByPaths(task sealtasks.TaskType, inPaths []stores.StorageInfo) ([]WorkerID, map[WorkerID]stores.StorageInfo) {
 	m.workersLk.Lock()
 	defer m.workersLk.Unlock()
 
@@ -249,8 +230,8 @@ func (m *Manager) getWorker(ctx context.Context, taskType sealtasks.TaskType, ac
 		taskType: taskType,
 		accept:   accept,
 
-		cancel: ctx.Done(),
-		ret:    ret,
+		ctx: ctx.Done(),
+		ret: ret,
 	}:
 	case <-m.closing:
 		return nil, nil, xerrors.New("closing")
@@ -266,6 +247,16 @@ func (m *Manager) getWorker(ctx context.Context, taskType sealtasks.TaskType, ac
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()
 	}
+}*/
+
+func schedNop(context.Context, Worker) error {
+	return nil
+}
+
+func schedFetch(sector abi.SectorID, ft stores.SectorFileType, sealing bool) func(context.Context, Worker) error {
+	return func(ctx context.Context, worker Worker) error {
+		return worker.Fetch(ctx, sector, ft, sealing)
+	}
 }
 
 func (m *Manager) NewSector(ctx context.Context, sector abi.SectorID) error {
@@ -274,151 +265,114 @@ func (m *Manager) NewSector(ctx context.Context, sector abi.SectorID) error {
 }
 
 func (m *Manager) AddPiece(ctx context.Context, sector abi.SectorID, existingPieces []abi.UnpaddedPieceSize, sz abi.UnpaddedPieceSize, r io.Reader) (abi.PieceInfo, error) {
-	// TODO: consider multiple paths vs workers when initially allocating
-
-	var best []stores.StorageInfo
+	var selector WorkerSelector
 	var err error
 	if len(existingPieces) == 0 { // new
-		best, err = m.index.StorageBestAlloc(ctx, stores.FTUnsealed, true)
+		selector, err = newAllocSelector(ctx, m.index, stores.FTUnsealed)
 	} else { // append to existing
-		best, err = m.index.StorageFindSector(ctx, sector, stores.FTUnsealed, false)
+		selector, err = newExistingSelector(ctx, m.index, sector, stores.FTUnsealed, false)
 	}
 	if err != nil {
-		return abi.PieceInfo{}, xerrors.Errorf("finding sector path: %w", err)
+		return abi.PieceInfo{}, xerrors.Errorf("creating path selector: %w", err)
 	}
 
-	log.Debugf("find workers for %v", best)
-	candidateWorkers, _ := m.getWorkersByPaths(sealtasks.TTAddPiece, best)
+	var out abi.PieceInfo
+	err = m.sched.Schedule(ctx, sealtasks.TTAddPiece, selector, schedNop, func(ctx context.Context, w Worker) error {
+		p, err := w.AddPiece(ctx, sector, existingPieces, sz, r)
+		if err != nil {
+			return err
+		}
+		out = p
+		return nil
+	})
 
-	if len(candidateWorkers) == 0 {
-		return abi.PieceInfo{}, ErrNoWorkers
-	}
-
-	worker, done, err := m.getWorker(ctx, sealtasks.TTAddPiece, candidateWorkers)
-	if err != nil {
-		return abi.PieceInfo{}, xerrors.Errorf("scheduling worker: %w", err)
-	}
-	defer done()
-
-	// TODO: select(candidateWorkers, ...)
-	// TODO: remove the sectorbuilder abstraction, pass path directly
-	return worker.AddPiece(ctx, sector, existingPieces, sz, r)
+	return out, err
 }
 
 func (m *Manager) SealPreCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, pieces []abi.PieceInfo) (out storage.PreCommit1Out, err error) {
 	// TODO: also consider where the unsealed data sits
 
-	best, err := m.index.StorageBestAlloc(ctx, stores.FTCache|stores.FTSealed, true)
+	selector, err := newAllocSelector(ctx, m.index, stores.FTCache|stores.FTSealed)
 	if err != nil {
-		return nil, xerrors.Errorf("finding path for sector sealing: %w", err)
+		return nil, xerrors.Errorf("creating path selector: %w", err)
 	}
 
-	candidateWorkers, _ := m.getWorkersByPaths(sealtasks.TTPreCommit1, best)
-	if len(candidateWorkers) == 0 {
-		return nil, ErrNoWorkers
-	}
+	err = m.sched.Schedule(ctx, sealtasks.TTPreCommit1, selector, schedFetch(sector, stores.FTUnsealed, true), func(ctx context.Context, w Worker) error {
+		p, err := w.SealPreCommit1(ctx, sector, ticket, pieces)
+		if err != nil {
+			return err
+		}
+		out = p
+		return nil
+	})
 
-	worker, done, err := m.getWorker(ctx, sealtasks.TTPreCommit1, candidateWorkers)
-	if err != nil {
-		return nil, xerrors.Errorf("scheduling worker: %w", err)
-	}
-	defer done()
-
-	// TODO: select(candidateWorkers, ...)
-	// TODO: remove the sectorbuilder abstraction, pass path directly
-	return worker.SealPreCommit1(ctx, sector, ticket, pieces)
+	return out, err
 }
 
-func (m *Manager) SealPreCommit2(ctx context.Context, sector abi.SectorID, phase1Out storage.PreCommit1Out) (cids storage.SectorCids, err error) {
-	// TODO: allow workers to fetch the sectors
-
-	best, err := m.index.StorageFindSector(ctx, sector, stores.FTCache|stores.FTSealed, true)
+func (m *Manager) SealPreCommit2(ctx context.Context, sector abi.SectorID, phase1Out storage.PreCommit1Out) (out storage.SectorCids, err error) {
+	selector, err := newExistingSelector(ctx, m.index, sector, stores.FTCache|stores.FTSealed, true)
 	if err != nil {
-		return storage.SectorCids{}, xerrors.Errorf("finding path for sector sealing: %w", err)
+		return storage.SectorCids{}, xerrors.Errorf("creating path selector: %w", err)
 	}
 
-	candidateWorkers, _ := m.getWorkersByPaths(sealtasks.TTPreCommit2, best)
-	if len(candidateWorkers) == 0 {
-		return storage.SectorCids{}, ErrNoWorkers
-	}
-
-	worker, done, err := m.getWorker(ctx, sealtasks.TTPreCommit2, candidateWorkers)
-	if err != nil {
-		return storage.SectorCids{}, xerrors.Errorf("scheduling worker: %w", err)
-	}
-	defer done()
-
-	// TODO: select(candidateWorkers, ...)
-	// TODO: remove the sectorbuilder abstraction, pass path directly
-	return worker.SealPreCommit2(ctx, sector, phase1Out)
+	err = m.sched.Schedule(ctx, sealtasks.TTPreCommit2, selector, schedFetch(sector, stores.FTCache|stores.FTSealed, true), func(ctx context.Context, w Worker) error {
+		p, err := w.SealPreCommit2(ctx, sector, phase1Out)
+		if err != nil {
+			return err
+		}
+		out = p
+		return nil
+	})
+	return out, err
 }
 
-func (m *Manager) SealCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, cids storage.SectorCids) (output storage.Commit1Out, err error) {
-	best, err := m.index.StorageFindSector(ctx, sector, stores.FTCache|stores.FTSealed, true)
+func (m *Manager) SealCommit1(ctx context.Context, sector abi.SectorID, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, cids storage.SectorCids) (out storage.Commit1Out, err error) {
+	selector, err := newExistingSelector(ctx, m.index, sector, stores.FTCache|stores.FTSealed, false)
 	if err != nil {
-		return nil, xerrors.Errorf("finding path for sector sealing: %w", err)
-	}
-
-	candidateWorkers, _ := m.getWorkersByPaths(sealtasks.TTCommit1, best)
-	if len(candidateWorkers) == 0 {
-		return nil, ErrNoWorkers
+		return storage.Commit1Out{}, xerrors.Errorf("creating path selector: %w", err)
 	}
 
 	// TODO: Try very hard to execute on worker with access to the sectors
-	worker, done, err := m.getWorker(ctx, sealtasks.TTCommit1, candidateWorkers)
-	if err != nil {
-		return nil, xerrors.Errorf("scheduling worker: %w", err)
-	}
-	defer done()
-
-	// TODO: select(candidateWorkers, ...)
-	// TODO: remove the sectorbuilder abstraction, pass path directly
-	return worker.SealCommit1(ctx, sector, ticket, seed, pieces, cids)
+	//  (except, don't.. for now at least - we are using this step to bring data
+	//  into 'provable' storage. Optimally we'd do that in commit2, in parallel
+	//  with snark compute)
+	err = m.sched.Schedule(ctx, sealtasks.TTCommit1, selector, schedFetch(sector, stores.FTCache|stores.FTSealed, true), func(ctx context.Context, w Worker) error {
+		p, err := w.SealCommit1(ctx, sector, ticket, seed, pieces, cids)
+		if err != nil {
+			return err
+		}
+		out = p
+		return nil
+	})
+	return out, err
 }
 
-func (m *Manager) SealCommit2(ctx context.Context, sector abi.SectorID, phase1Out storage.Commit1Out) (proof storage.Proof, err error) {
-	var candidateWorkers []WorkerID
+func (m *Manager) SealCommit2(ctx context.Context, sector abi.SectorID, phase1Out storage.Commit1Out) (out storage.Proof, err error) {
+	selector := newTaskSelector()
 
-	m.workersLk.Lock()
-	for id, worker := range m.workers {
-		tt, err := worker.w.TaskTypes(ctx)
+	err = m.sched.Schedule(ctx, sealtasks.TTCommit2, selector, schedNop, func(ctx context.Context, w Worker) error {
+		p, err := w.SealCommit2(ctx, sector, phase1Out)
 		if err != nil {
-			log.Errorf("error getting supported worker task types: %+v", err)
-			continue
+			return err
 		}
-		if _, ok := tt[sealtasks.TTCommit2]; !ok {
-			continue
-		}
-		candidateWorkers = append(candidateWorkers, id)
-	}
-	m.workersLk.Unlock()
-	if len(candidateWorkers) == 0 {
-		return nil, ErrNoWorkers
-	}
+		out = p
+		return nil
+	})
 
-	worker, done, err := m.getWorker(ctx, sealtasks.TTCommit2, candidateWorkers)
-	if err != nil {
-		return nil, xerrors.Errorf("scheduling worker: %w", err)
-	}
-	defer done()
-
-	return worker.SealCommit2(ctx, sector, phase1Out)
+	return out, err
 }
 
 func (m *Manager) FinalizeSector(ctx context.Context, sector abi.SectorID) error {
-	best, err := m.index.StorageFindSector(ctx, sector, stores.FTCache|stores.FTSealed|stores.FTUnsealed, true)
+	selector, err := newExistingSelector(ctx, m.index, sector, stores.FTCache|stores.FTSealed|stores.FTUnsealed, false)
 	if err != nil {
-		return xerrors.Errorf("finding sealed sector: %w", err)
+		return xerrors.Errorf("creating path selector: %w", err)
 	}
 
-	candidateWorkers, _ := m.getWorkersByPaths(sealtasks.TTFinalize, best)
-	if len(candidateWorkers) == 0 {
-		return ErrNoWorkers
-	}
-
-	// TODO: Remove sector from sealing stores
-	// TODO: Move the sector to long-term storage
-	return m.workers[candidateWorkers[0]].w.FinalizeSector(ctx, sector)
+	return m.sched.Schedule(ctx, sealtasks.TTFinalize, selector,
+		schedFetch(sector, stores.FTCache|stores.FTSealed|stores.FTUnsealed, false),
+		func(ctx context.Context, w Worker) error {
+			return w.FinalizeSector(ctx, sector)
+		})
 }
 
 func (m *Manager) StorageLocal(ctx context.Context) (map[stores.ID]string, error) {
@@ -440,8 +394,7 @@ func (m *Manager) FsStat(ctx context.Context, id stores.ID) (stores.FsStat, erro
 }
 
 func (m *Manager) Close() error {
-	close(m.closing)
-	return nil
+	return m.sched.Close()
 }
 
 var _ SectorManager = &Manager{}

--- a/manager.go
+++ b/manager.go
@@ -30,6 +30,7 @@ type URLs []string
 
 type Worker interface {
 	ffiwrapper.StorageSealer
+	Fetch(context.Context, abi.SectorID, stores.SectorFileType, bool) error
 
 	TaskTypes(context.Context) (map[sealtasks.TaskType]struct{}, error)
 
@@ -122,7 +123,7 @@ func New(ctx context.Context, ls stores.LocalStorage, si stores.SectorIndex, cfg
 	go m.runSched()
 
 	localTasks := []sealtasks.TaskType{
-		sealtasks.TTAddPiece, sealtasks.TTCommit1, sealtasks.TTFinalize,
+		sealtasks.TTAddPiece, sealtasks.TTCommit1, sealtasks.TTFinalize, sealtasks.TTFetch,
 	}
 	if sc.AllowPreCommit1 {
 		localTasks = append(localTasks, sealtasks.TTPreCommit1)

--- a/resources.go
+++ b/resources.go
@@ -23,10 +23,14 @@ type Resources struct {
 	MinMemory uint64 // What Must be in RAM for decent perf
 	MaxMemory uint64 // Memory required (swap + ram)
 
-	MultiThread bool
-	CanGPU      bool
+	Threads int // -1 = multithread
+	CanGPU  bool
 
 	BaseMinMemory uint64 // What Must be in RAM for decent perf (shared between threads)
+}
+
+func (r Resources) MultiThread() bool {
+	return r.Threads == -1
 }
 
 const MaxCachingOverhead = 32 << 30
@@ -37,7 +41,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 32 << 30,
 			MinMemory: 32 << 30,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -45,7 +49,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 1 << 30,
 			MinMemory: 1 << 30,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -53,7 +57,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 2 << 10,
 			MinMemory: 2 << 10,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 2 << 10,
 		},
@@ -61,7 +65,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 8 << 20,
 			MinMemory: 8 << 20,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 8 << 20,
 		},
@@ -71,7 +75,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 64 << 30,
 			MinMemory: 32 << 30,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 30 << 30,
 		},
@@ -79,7 +83,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 3 << 29, // 1.5G
 			MinMemory: 1 << 30,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -87,7 +91,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 2 << 10,
 			MinMemory: 2 << 10,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 2 << 10,
 		},
@@ -95,7 +99,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 8 << 20,
 			MinMemory: 8 << 20,
 
-			MultiThread: false,
+			Threads: 1,
 
 			BaseMinMemory: 8 << 20,
 		},
@@ -105,7 +109,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 96 << 30,
 			MinMemory: 64 << 30,
 
-			MultiThread: true,
+			Threads: -1,
 
 			BaseMinMemory: 30 << 30,
 		},
@@ -113,7 +117,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 3 << 29, // 1.5G
 			MinMemory: 1 << 30,
 
-			MultiThread: true,
+			Threads: -1,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -121,7 +125,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 2 << 10,
 			MinMemory: 2 << 10,
 
-			MultiThread: true,
+			Threads: -1,
 
 			BaseMinMemory: 2 << 10,
 		},
@@ -129,7 +133,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 8 << 20,
 			MinMemory: 8 << 20,
 
-			MultiThread: true,
+			Threads: -1,
 
 			BaseMinMemory: 8 << 20,
 		},
@@ -139,7 +143,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 1 << 30,
 			MinMemory: 1 << 30,
 
-			MultiThread: false,
+			Threads: 0,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -147,7 +151,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 1 << 30,
 			MinMemory: 1 << 30,
 
-			MultiThread: false,
+			Threads: 0,
 
 			BaseMinMemory: 1 << 30,
 		},
@@ -155,7 +159,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 2 << 10,
 			MinMemory: 2 << 10,
 
-			MultiThread: false,
+			Threads: 0,
 
 			BaseMinMemory: 2 << 10,
 		},
@@ -163,7 +167,7 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 8 << 20,
 			MinMemory: 8 << 20,
 
-			MultiThread: false,
+			Threads: 0,
 
 			BaseMinMemory: 8 << 20,
 		},
@@ -173,8 +177,8 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 110 << 30,
 			MinMemory: 60 << 30,
 
-			MultiThread: true,
-			CanGPU:      true,
+			Threads: -1,
+			CanGPU:  true,
 
 			BaseMinMemory: 64 << 30, // params
 		},
@@ -182,8 +186,8 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 3 << 29, // 1.5G
 			MinMemory: 1 << 30,
 
-			MultiThread: false, // This is fine
-			CanGPU:      true,
+			Threads: 1, // This is fine
+			CanGPU:  true,
 
 			BaseMinMemory: 10 << 30,
 		},
@@ -191,8 +195,8 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 2 << 10,
 			MinMemory: 2 << 10,
 
-			MultiThread: false,
-			CanGPU:      true,
+			Threads: 1,
+			CanGPU:  true,
 
 			BaseMinMemory: 2 << 10,
 		},
@@ -200,10 +204,48 @@ var ResourceTable = map[sealtasks.TaskType]map[abi.RegisteredProof]Resources{
 			MaxMemory: 8 << 20,
 			MinMemory: 8 << 20,
 
-			MultiThread: false,
-			CanGPU:      true,
+			Threads: 1,
+			CanGPU:  true,
 
 			BaseMinMemory: 8 << 20,
+		},
+	},
+	sealtasks.TTFetch: {
+		abi.RegisteredProof_StackedDRG32GiBSeal: Resources{
+			MaxMemory: 1 << 20,
+			MinMemory: 1 << 20,
+
+			Threads: 0,
+			CanGPU:  false,
+
+			BaseMinMemory: 0,
+		},
+		abi.RegisteredProof_StackedDRG512MiBSeal: Resources{
+			MaxMemory: 1 << 20,
+			MinMemory: 1 << 20,
+
+			Threads: 0,
+			CanGPU:  false,
+
+			BaseMinMemory: 0,
+		},
+		abi.RegisteredProof_StackedDRG2KiBSeal: Resources{
+			MaxMemory: 1 << 20,
+			MinMemory: 1 << 20,
+
+			Threads: 0,
+			CanGPU:  false,
+
+			BaseMinMemory: 0,
+		},
+		abi.RegisteredProof_StackedDRG8MiBSeal: Resources{
+			MaxMemory: 1 << 20,
+			MinMemory: 1 << 20,
+
+			Threads: 0,
+			CanGPU:  false,
+
+			BaseMinMemory: 0,
 		},
 	},
 }

--- a/sched.go
+++ b/sched.go
@@ -373,6 +373,11 @@ func canHandleRequest(needRes Resources, spt abi.RegisteredProof, wid WorkerID, 
 			log.Debugf("sched: not scheduling on worker %d; multicore process needs %d threads, %d in use, target %d", wid, res.CPUs, active.cpuUse, res.CPUs)
 			return false
 		}
+	} else {
+		if active.cpuUse + uint64(needRes.Threads) > res.CPUs {
+			log.Debugf("sched: not scheduling on worker %d; not enough threads, need %d, %d in use, target %d", wid, needRes.Threads, active.cpuUse, res.CPUs)
+			return false
+		}
 	}
 
 	if len(res.GPUs) > 0 && needRes.CanGPU {

--- a/sched.go
+++ b/sched.go
@@ -293,6 +293,11 @@ func (sh *scheduler) assignWorker(wid WorkerID, w *workerHandle, req *workerRequ
 		})
 
 		sh.workersLk.Unlock()
+
+		// This error should always be nil, since nothing is setting it, but just to be safe:
+		if err != nil {
+			log.Errorf("error executing worker (withResources): %+v", err)
+		}
 	}()
 
 	return nil

--- a/sealtasks/task.go
+++ b/sealtasks/task.go
@@ -10,4 +10,6 @@ const (
 	TTCommit2    TaskType = "seal/v0/commit/2"
 
 	TTFinalize TaskType = "seal/v0/finalize"
+
+	TTFetch TaskType = "seal/v0/fetch"
 )

--- a/selector_alloc.go
+++ b/selector_alloc.go
@@ -53,7 +53,7 @@ func (s *allocSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *w
 }
 
 func (s *allocSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
-	return a.info.Hostname > b.info.Hostname, nil // TODO: Better strategy
+	return a.active.utilization(a.info.Resources) < b.active.utilization(b.info.Resources), nil
 }
 
 var _ WorkerSelector = &allocSelector{}

--- a/selector_alloc.go
+++ b/selector_alloc.go
@@ -1,0 +1,59 @@
+package sectorstorage
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sector-storage/sealtasks"
+	"github.com/filecoin-project/sector-storage/stores"
+)
+
+type allocSelector struct {
+	best []stores.StorageInfo
+}
+
+func newAllocSelector(ctx context.Context, index stores.SectorIndex, alloc stores.SectorFileType) (*allocSelector, error) {
+	best, err := index.StorageBestAlloc(ctx, alloc, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &allocSelector{
+		best: best,
+	}, nil
+}
+
+func (s *allocSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *workerHandle) (bool, error) {
+	tasks, err := whnd.w.TaskTypes(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting supported worker task types: %w", err)
+	}
+	if _, supported := tasks[task]; !supported {
+		return false, nil
+	}
+
+	paths, err := whnd.w.Paths(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting worker paths: %w", err)
+	}
+
+	have := map[stores.ID]struct{}{}
+	for _, path := range paths {
+		have[path.ID] = struct{}{}
+	}
+
+	for _, info := range s.best {
+		if _, ok := have[info.ID]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *allocSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
+	return a.info.Hostname > b.info.Hostname, nil // TODO: Better strategy
+}
+
+var _ WorkerSelector = &allocSelector{}

--- a/selector_existing.go
+++ b/selector_existing.go
@@ -1,0 +1,60 @@
+package sectorstorage
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sector-storage/sealtasks"
+	"github.com/filecoin-project/sector-storage/stores"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+type existingSelector struct {
+	best []stores.StorageInfo
+}
+
+func newExistingSelector(ctx context.Context, index stores.SectorIndex, sector abi.SectorID, alloc stores.SectorFileType, allowFetch bool) (*existingSelector, error) {
+	best, err := index.StorageFindSector(ctx, sector, alloc, allowFetch)
+	if err != nil {
+		return nil, err
+	}
+
+	return &existingSelector{
+		best: best,
+	}, nil
+}
+
+func (s *existingSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *workerHandle) (bool, error) {
+	tasks, err := whnd.w.TaskTypes(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting supported worker task types: %w", err)
+	}
+	if _, supported := tasks[task]; !supported {
+		return false, nil
+	}
+
+	paths, err := whnd.w.Paths(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting worker paths: %w", err)
+	}
+
+	have := map[stores.ID]struct{}{}
+	for _, path := range paths {
+		have[path.ID] = struct{}{}
+	}
+
+	for _, info := range s.best {
+		if _, ok := have[info.ID]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *existingSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
+	return a.info.Hostname > b.info.Hostname, nil // TODO: Better strategy
+}
+
+var _ WorkerSelector = &existingSelector{}

--- a/selector_existing.go
+++ b/selector_existing.go
@@ -54,7 +54,7 @@ func (s *existingSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd
 }
 
 func (s *existingSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
-	return a.info.Hostname > b.info.Hostname, nil // TODO: Better strategy
+	return a.active.utilization(a.info.Resources) < b.active.utilization(b.info.Resources), nil
 }
 
 var _ WorkerSelector = &existingSelector{}

--- a/selector_task.go
+++ b/selector_task.go
@@ -40,7 +40,7 @@ func (s *taskSelector) Cmp(ctx context.Context, _ sealtasks.TaskType, a, b *work
 		return len(atasks) < len(btasks), nil // prefer workers which can do less
 	}
 
-	return a.info.Hostname > b.info.Hostname, nil // TODO: Better fallback strategy
+	return a.active.utilization(a.info.Resources) < b.active.utilization(b.info.Resources), nil
 }
 
 var _ WorkerSelector = &allocSelector{}

--- a/selector_task.go
+++ b/selector_task.go
@@ -1,0 +1,46 @@
+package sectorstorage
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/sector-storage/sealtasks"
+	"github.com/filecoin-project/sector-storage/stores"
+)
+
+type taskSelector struct {
+	best []stores.StorageInfo
+}
+
+func newTaskSelector() *taskSelector {
+	return &taskSelector{}
+}
+
+func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *workerHandle) (bool, error) {
+	tasks, err := whnd.w.TaskTypes(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting supported worker task types: %w", err)
+	}
+	_, supported := tasks[task]
+
+	return supported, nil
+}
+
+func (s *taskSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
+	atasks, err := a.w.TaskTypes(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting supported worker task types: %w", err)
+	}
+	btasks, err := b.w.TaskTypes(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("getting supported worker task types: %w", err)
+	}
+	if len(atasks) != len(btasks) {
+		return len(atasks) < len(btasks), nil // prefer workers which can do less
+	}
+
+	return a.info.Hostname > a.info.Hostname, nil // TODO: Better fallback strategy
+}
+
+var _ WorkerSelector = &allocSelector{}

--- a/selector_task.go
+++ b/selector_task.go
@@ -27,7 +27,7 @@ func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *wo
 	return supported, nil
 }
 
-func (s *taskSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) {
+func (s *taskSelector) Cmp(ctx context.Context, _ sealtasks.TaskType, a, b *workerHandle) (bool, error) {
 	atasks, err := a.w.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)
@@ -40,7 +40,7 @@ func (s *taskSelector) Cmp(ctx context.Context, task sealtasks.TaskType, a, b *w
 		return len(atasks) < len(btasks), nil // prefer workers which can do less
 	}
 
-	return a.info.Hostname > a.info.Hostname, nil // TODO: Better fallback strategy
+	return a.info.Hostname > b.info.Hostname, nil // TODO: Better fallback strategy
 }
 
 var _ WorkerSelector = &allocSelector{}

--- a/stats.go
+++ b/stats.go
@@ -11,10 +11,10 @@ func (m *Manager) WorkerStats() map[uint64]storiface.WorkerStats {
 	for id, handle := range m.sched.workers {
 		out[uint64(id)] = storiface.WorkerStats{
 			Info:       handle.info,
-			MemUsedMin: handle.memUsedMin,
-			MemUsedMax: handle.memUsedMax,
-			GpuUsed:    handle.gpuUsed,
-			CpuUse:     handle.cpuUse,
+			MemUsedMin: handle.active.memUsedMin,
+			MemUsedMax: handle.active.memUsedMax,
+			GpuUsed:    handle.active.gpuUsed,
+			CpuUse:     handle.active.cpuUse,
 		}
 	}
 

--- a/stats.go
+++ b/stats.go
@@ -3,12 +3,12 @@ package sectorstorage
 import "github.com/filecoin-project/sector-storage/storiface"
 
 func (m *Manager) WorkerStats() map[uint64]storiface.WorkerStats {
-	m.workersLk.Lock()
-	defer m.workersLk.Unlock()
+	m.sched.workersLk.Lock()
+	defer m.sched.workersLk.Unlock()
 
 	out := map[uint64]storiface.WorkerStats{}
 
-	for id, handle := range m.workers {
+	for id, handle := range m.sched.workers {
 		out[uint64(id)] = storiface.WorkerStats{
 			Info:       handle.info,
 			MemUsedMin: handle.memUsedMin,

--- a/stores/index.go
+++ b/stores/index.go
@@ -277,11 +277,9 @@ func (i *Index) StorageBestAlloc(ctx context.Context, allocate SectorFileType, s
 
 	for _, p := range i.stores {
 		if sealing && !p.info.CanSeal {
-			log.Debugf("alloc: not considering %s; can't seal", p.info.ID)
 			continue
 		}
 		if !sealing && !p.info.CanStore {
-			log.Debugf("alloc: not considering %s; can't store", p.info.ID)
 			continue
 		}
 

--- a/stores/index.go
+++ b/stores/index.go
@@ -63,6 +63,9 @@ func NewIndex() *Index {
 }
 
 func (i *Index) StorageList(ctx context.Context) (map[ID][]Decl, error) {
+	i.lk.RLock()
+	defer i.lk.RUnlock()
+
 	byID := map[ID]map[abi.SectorID]SectorFileType{}
 
 	for id := range i.stores {

--- a/stores/remote.go
+++ b/stores/remote.go
@@ -92,7 +92,11 @@ func (r *Remote) acquireFromRemote(ctx context.Context, s abi.SectorID, fileType
 		return "", "", "", nil, err
 	}
 
-	sort.Slice(si, func(i, j int) bool {
+	if len(si) == 0 {
+		return "", "", "", nil, xerrors.Errorf("failed to acquire sector %v from remote(%d): not found", s, fileType)
+	}
+
+		sort.Slice(si, func(i, j int) bool {
 		return si[i].Weight < si[j].Weight
 	})
 

--- a/stores/remote.go
+++ b/stores/remote.go
@@ -27,9 +27,8 @@ type Remote struct {
 	index SectorIndex
 	auth  http.Header
 
-	fetchLk sync.Mutex // TODO: this can be much smarter
-	// TODO: allow multiple parallel fetches
-	//  (make sure to not fetch the same sector data twice)
+	fetchLk sync.Mutex
+	fetching map[abi.SectorID]chan struct{}
 }
 
 func NewRemote(local *Local, index SectorIndex, auth http.Header) *Remote {
@@ -37,6 +36,8 @@ func NewRemote(local *Local, index SectorIndex, auth http.Header) *Remote {
 		local: local,
 		index: index,
 		auth:  auth,
+
+		fetching: map[abi.SectorID]chan struct{}{},
 	}
 }
 
@@ -45,8 +46,32 @@ func (r *Remote) AcquireSector(ctx context.Context, s abi.SectorID, existing Sec
 		return SectorPaths{}, SectorPaths{}, nil, xerrors.New("can't both find and allocate a sector")
 	}
 
-	r.fetchLk.Lock()
-	defer r.fetchLk.Unlock()
+	for {
+		r.fetchLk.Lock()
+
+		c, locked := r.fetching[s]
+		if !locked {
+			r.fetching[s] = make(chan struct{})
+			r.fetchLk.Unlock()
+			break
+		}
+
+		r.fetchLk.Unlock()
+
+		select {
+		case <-c:
+			continue
+		case <-ctx.Done():
+			return SectorPaths{}, SectorPaths{}, nil, ctx.Err()
+		}
+	}
+
+	defer func() {
+		r.fetchLk.Lock()
+		close(r.fetching[s])
+		delete(r.fetching, s)
+		r.fetchLk.Unlock()
+	}()
 
 	paths, stores, done, err := r.local.AcquireSector(ctx, s, existing, allocate, sealing)
 	if err != nil {

--- a/storiface/worker.go
+++ b/storiface/worker.go
@@ -22,5 +22,5 @@ type WorkerStats struct {
 	MemUsedMin uint64
 	MemUsedMax uint64
 	GpuUsed    bool
-	CpuUse     int
+	CpuUse     uint64
 }

--- a/storiface/worker.go
+++ b/storiface/worker.go
@@ -12,6 +12,7 @@ type WorkerResources struct {
 
 	MemReserved uint64 // Used by system / other processes
 
+	CPUs uint64 // Logical cores
 	GPUs []string
 }
 


### PR DESCRIPTION
This addresses https://github.com/filecoin-project/sector-storage/issues/17 by:

* Adding a 'fetch' worker task (currently not exposed on by the manager, and only used internally)
* prefetching sector data before running compute on them (scheduler now has separate, per-worker resource pools for data fetching and compute)

Also cleaned up the scheduling logic a bit, which should make it more testable, and make it easier to extend later.