### PR TITLE
Improve storage selection logic

### DIFF
--- a/localworker.go
+++ b/localworker.go
@@ -58,7 +58,7 @@ type localWorkerPathProvider struct {
 }
 
 func (l *localWorkerPathProvider) AcquireSector(ctx context.Context, sector abi.SectorID, existing stores.SectorFileType, allocate stores.SectorFileType, sealing bool) (stores.SectorPaths, func(), error) {
-	paths, storageIDs, done, err := l.w.storage.AcquireSector(ctx, sector, existing, allocate, sealing)
+	paths, storageIDs, done, err := l.w.storage.AcquireSector(ctx, sector, l.w.scfg.SealProofType, existing, allocate, sealing)
 	if err != nil {
 		return stores.SectorPaths{}, nil, err
 	}
@@ -163,7 +163,7 @@ func (l *LocalWorker) FinalizeSector(ctx context.Context, sector abi.SectorID) e
 		return xerrors.Errorf("removing unsealed data: %w", err)
 	}
 
-	if err := l.storage.MoveStorage(ctx, sector, stores.FTSealed|stores.FTCache); err != nil {
+	if err := l.storage.MoveStorage(ctx, sector, l.scfg.SealProofType, stores.FTSealed|stores.FTCache); err != nil {
 		return xerrors.Errorf("moving sealed data to storage: %w", err)
 	}
 

--- a/resources.go
+++ b/resources.go
@@ -4,20 +4,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 
 	"github.com/filecoin-project/sector-storage/sealtasks"
-	"github.com/filecoin-project/sector-storage/stores"
 )
-
-var FSOverheadSeal = map[stores.SectorFileType]int{ // 10x overheads
-	stores.FTUnsealed: 10,
-	stores.FTSealed:   10,
-	stores.FTCache:    70, // TODO: confirm for 32G
-}
-
-var FsOverheadFinalized = map[stores.SectorFileType]int{
-	stores.FTUnsealed: 10,
-	stores.FTSealed:   10,
-	stores.FTCache:    2,
-}
 
 type Resources struct {
 	MinMemory uint64 // What Must be in RAM for decent perf

--- a/roprov.go
+++ b/roprov.go
@@ -12,6 +12,7 @@ import (
 
 type readonlyProvider struct {
 	stor *stores.Local
+	spt  abi.RegisteredProof
 }
 
 func (l *readonlyProvider) AcquireSector(ctx context.Context, id abi.SectorID, existing stores.SectorFileType, allocate stores.SectorFileType, sealing bool) (stores.SectorPaths, func(), error) {
@@ -19,7 +20,7 @@ func (l *readonlyProvider) AcquireSector(ctx context.Context, id abi.SectorID, e
 		return stores.SectorPaths{}, nil, xerrors.New("read-only storage")
 	}
 
-	p, _, done, err := l.stor.AcquireSector(ctx, id, existing, allocate, sealing)
+	p, _, done, err := l.stor.AcquireSector(ctx, id, l.spt, existing, allocate, sealing)
 
 	return p, done, err
 }

--- a/sched.go
+++ b/sched.go
@@ -20,7 +20,7 @@ const mib = 1 << 20
 type WorkerAction func(ctx context.Context, w Worker) error
 
 type WorkerSelector interface {
-	Ok(ctx context.Context, task sealtasks.TaskType, a *workerHandle) (bool, error) // true if worker is acceptable for performing a task
+	Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredProof, a *workerHandle) (bool, error) // true if worker is acceptable for performing a task
 
 	Cmp(ctx context.Context, task sealtasks.TaskType, a, b *workerHandle) (bool, error) // true if a is preferred over b
 }
@@ -178,7 +178,7 @@ func (sh *scheduler) onWorkerFreed(wid WorkerID) {
 	for i := 0; i < sh.schedQueue.Len(); i++ {
 		req := (*sh.schedQueue)[i]
 
-		ok, err := req.sel.Ok(req.ctx, req.taskType, w)
+		ok, err := req.sel.Ok(req.ctx, req.taskType, sh.spt, w)
 		if err != nil {
 			log.Errorf("onWorkerFreed req.sel.Ok error: %+v", err)
 			continue
@@ -212,7 +212,7 @@ func (sh *scheduler) maybeSchedRequest(req *workerRequest) (bool, error) {
 	needRes := ResourceTable[req.taskType][sh.spt]
 
 	for wid, worker := range sh.workers {
-		ok, err := req.sel.Ok(req.ctx, req.taskType, worker)
+		ok, err := req.sel.Ok(req.ctx, req.taskType, sh.spt, worker)
 		if err != nil {
 			return false, err
 		}

--- a/selector_existing.go
+++ b/selector_existing.go
@@ -5,9 +5,10 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
 	"github.com/filecoin-project/sector-storage/sealtasks"
 	"github.com/filecoin-project/sector-storage/stores"
-	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
 type existingSelector struct {
@@ -25,7 +26,7 @@ func newExistingSelector(ctx context.Context, index stores.SectorIndex, sector a
 	}, nil
 }
 
-func (s *existingSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *workerHandle) (bool, error) {
+func (s *existingSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredProof, whnd *workerHandle) (bool, error) {
 	tasks, err := whnd.w.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)

--- a/selector_task.go
+++ b/selector_task.go
@@ -5,6 +5,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
 	"github.com/filecoin-project/sector-storage/sealtasks"
 	"github.com/filecoin-project/sector-storage/stores"
 )
@@ -17,7 +19,7 @@ func newTaskSelector() *taskSelector {
 	return &taskSelector{}
 }
 
-func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, whnd *workerHandle) (bool, error) {
+func (s *taskSelector) Ok(ctx context.Context, task sealtasks.TaskType, spt abi.RegisteredProof, whnd *workerHandle) (bool, error) {
 	tasks, err := whnd.w.TaskTypes(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting supported worker task types: %w", err)

--- a/stores/http_handler.go
+++ b/stores/http_handler.go
@@ -68,7 +68,9 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 		w.WriteHeader(500)
 		return
 	}
-	paths, _, done, err := handler.Local.AcquireSector(r.Context(), id, ft, FTNone, false)
+
+	// passing 0 spt because we don't allocate anything
+	paths, _, done, err := handler.Local.AcquireSector(r.Context(), id, 0, ft, FTNone, false)
 	if err != nil {
 		log.Error("%+v", err)
 		w.WriteHeader(500)

--- a/stores/interface.go
+++ b/stores/interface.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Store interface {
-	AcquireSector(ctx context.Context, s abi.SectorID, existing SectorFileType, allocate SectorFileType, sealing bool) (paths SectorPaths, stores SectorPaths, done func(), err error)
+	AcquireSector(ctx context.Context, s abi.SectorID, spt abi.RegisteredProof, existing SectorFileType, allocate SectorFileType, sealing bool) (paths SectorPaths, stores SectorPaths, done func(), err error)
 	Remove(ctx context.Context, s abi.SectorID, types SectorFileType) error
 
 	// move sectors into storage
-	MoveStorage(ctx context.Context, s abi.SectorID, types SectorFileType) error
+	MoveStorage(ctx context.Context, s abi.SectorID, spt abi.RegisteredProof, types SectorFileType) error
 
 	FsStat(ctx context.Context, id ID) (FsStat, error)
 }

--- a/stores/local.go
+++ b/stores/local.go
@@ -164,7 +164,7 @@ func (st *Local) open(ctx context.Context) error {
 
 func (st *Local) reportHealth(ctx context.Context) {
 	// randomize interval by ~10%
-	interval := (HeartBeatInterval*100_000 + time.Duration(rand.Int63n(10_000))) / 100_000
+	interval := (HeartbeatInterval*100_000 + time.Duration(rand.Int63n(10_000))) / 100_000
 
 	for {
 		select {
@@ -195,7 +195,7 @@ func (st *Local) reportHealth(ctx context.Context) {
 	}
 }
 
-func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, existing SectorFileType, allocate SectorFileType, sealing bool) (SectorPaths, SectorPaths, func(), error) {
+func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, spt abi.RegisteredProof, existing SectorFileType, allocate SectorFileType, sealing bool) (SectorPaths, SectorPaths, func(), error) {
 	if existing|allocate != existing^allocate {
 		return SectorPaths{}, SectorPaths{}, nil, xerrors.New("can't both find and allocate a sector")
 	}
@@ -240,7 +240,7 @@ func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, existing S
 			continue
 		}
 
-		sis, err := st.index.StorageBestAlloc(ctx, fileType, sealing)
+		sis, err := st.index.StorageBestAlloc(ctx, fileType, spt, sealing)
 		if err != nil {
 			st.localLk.RUnlock()
 			return SectorPaths{}, SectorPaths{}, nil, xerrors.Errorf("finding best storage for allocating : %w", err)
@@ -352,14 +352,14 @@ func (st *Local) Remove(ctx context.Context, sid abi.SectorID, typ SectorFileTyp
 	return nil
 }
 
-func (st *Local) MoveStorage(ctx context.Context, s abi.SectorID, types SectorFileType) error {
-	dest, destIds, sdone, err := st.AcquireSector(ctx, s, FTNone, types, false)
+func (st *Local) MoveStorage(ctx context.Context, s abi.SectorID, spt abi.RegisteredProof, types SectorFileType) error {
+	dest, destIds, sdone, err := st.AcquireSector(ctx, s, spt, FTNone, types, false)
 	if err != nil {
 		return xerrors.Errorf("acquire dest storage: %w", err)
 	}
 	defer sdone()
 
-	src, srcIds, ddone, err := st.AcquireSector(ctx, s, types, FTNone, false)
+	src, srcIds, ddone, err := st.AcquireSector(ctx, s, spt, types, FTNone, false)
 	if err != nil {
 		return xerrors.Errorf("acquire src storage: %w", err)
 	}


### PR DESCRIPTION
TODO:
- [x] Integrate with lotus (should be a simple update)

This should prevent sectors from being allocated in storage that doesn't have enough space for those sectors.

(still not perfect, a situation where 2 sectors are assigned to one storage which only has space for one can still happen, but that's much easier to recover from, and we have mechanisms that should handle that already)