### PR TITLE
fix fallocate failed on cephfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/filecoin-project/sector-storage
 go 1.13
 
 require (
-	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e
 	github.com/elastic/go-sysinfo v1.3.0
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200326153646-e899cc1dd072
 	github.com/filecoin-project/go-bitfield v0.0.2-0.20200518150651-562fdb554b6e

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e h1:lj77EKYUpYXTd8CD/+QMIf8b6OIOTsfEBSXiAzuEHTU=
-github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e/go.mod h1:3ZQK6DMPSz/QZ73jlWxBtUhNA8xZx7LzUFSq/OfP8vk=
 github.com/elastic/go-sysinfo v1.3.0 h1:eb2XFGTMlSwG/yyU9Y8jVAYLIzU2sFzWXwo2gmetyrE=
 github.com/elastic/go-sysinfo v1.3.0/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=


### PR DESCRIPTION
when i try to seal a sector on my cephfs, it keeps reporting this error: 
```txt
2020-06-02T14:01:38.781+0800    ERROR   sectors add piece:                                                                                                      
    github.com/filecoin-project/storage-fsm.(*Sealing).pledgeSector
        /root/go/pkg/mod/github.com/filecoin-project/storage-fsm@v0.0.0-20200528050623-cdada6e88960/garbage.go:30
  - creating unsealed sector file:
    github.com/filecoin-project/sector-storage/ffiwrapper.(*Sealer).AddPiece
        /root/go/pkg/mod/github.com/filecoin-project/sector-storage@v0.0.0-20200529175241-9df0cdf19326/ffiwrapper/sealer_cgo.go:91
  - fallocate '/storage/lotus-storage-interop-02/unsealed/s-t01481-1':
    github.com/filecoin-project/sector-storage/ffiwrapper.createPartialFile.func1
        /root/go/pkg/mod/github.com/filecoin-project/sector-storage@v0.0.0-20200529175241-9df0cdf19326/ffiwrapper/partialfile.go:67
  - operation not supported
```
but its normal on other machines, then i found that it can be fixed by rewriting the fallocate function