### PR TITLE
local store: Fix double RUnlock

### DIFF
--- a/stores/local.go
+++ b/stores/local.go
@@ -245,7 +245,6 @@ func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, spt abi.Re
 
 		sis, err := st.index.StorageBestAlloc(ctx, fileType, spt, pathType)
 		if err != nil {
-			st.localLk.RUnlock()
 			return SectorPaths{}, SectorPaths{}, xerrors.Errorf("finding best storage for allocating : %w", err)
 		}
 
@@ -277,7 +276,6 @@ func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, spt abi.Re
 		}
 
 		if best == "" {
-			st.localLk.RUnlock()
 			return SectorPaths{}, SectorPaths{}, xerrors.Errorf("couldn't find a suitable path for a sector")
 		}
 


### PR DESCRIPTION
RUnlock is now defer-ed in that function, which means that if one of those errors was hit, we'd get
```
fatal error: sync: RUnlock of unlocked RWMutex                                                                                          
                                                                                                                                        
goroutine 3552577 [running]:
runtime.throw(0x1e12d65, 0x21)
        /usr/lib/go/src/runtime/panic.go:1116 +0x72 fp=0xc00023a3c0 sp=0xc00023a390 pc=0x53dea2
sync.throw(0x1e12d65, 0x21)
        /usr/lib/go/src/runtime/panic.go:1102 +0x35 fp=0xc00023a3e0 sp=0xc00023a3c0 pc=0x53de25
sync.(*RWMutex).rUnlockSlow(0xc0001b24c0, 0xffffffff)
        /usr/lib/go/src/sync/rwmutex.go:80 +0x3f fp=0xc00023a408 sp=0xc00023a3e0 pc=0x57becf
sync.(*RWMutex).RUnlock(0xc0001b24c0)
        /usr/lib/go/src/sync/rwmutex.go:70 +0x49 fp=0xc00023a428 sp=0xc00023a408 pc=0x57be79
github.com/filecoin-project/sector-storage/stores.(*Local).AcquireSector(0xc0001b2480, 0x20bbee0, 0xc000634210, 0x838, 0x33c, 0x7, 0x1, 
0x6, 0xc00023a801, 0x0, ...)
        /home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/sector-storage@v0.0.0-20200605192746-4b9317d1f08f/stores/local.go:281 
+0xa7e fp=0xc00023a848 sp=0xc00023a428 pc=0xa4d9be
github.com/filecoin-project/sector-storage/stores.(*Remote).AcquireSector(0xc0005f8d50, 0x20bbee0, 0xc000634210, 0x838, 0x33c, 0x7, 0x1,
 0x6, 0x1, 0x0, ...)
        /home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/sector-storage@v0.0.0-20200605192746-4b9317d1f08f/stores/remote.go:85 
+0x4b3 fp=0xc00023ac50 sp=0xc00023a848 pc=0xa51653
github.com/filecoin-project/sector-storage.(*localWorkerPathProvider).AcquireSector(0xc0003a6440, 0x20bbee0, 0xc000634210, 0x838, 0x33c,
 0x1, 0x6, 0xc00023af01, 0x0, 0x0, ...)
        /home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/sector-storage@v0.0.0-20200605192746-4b9317d1f08f/localworker.go:63 +0
x12b fp=0xc00023aec8 sp=0xc00023ac50 pc=0xc041fb
```