### PR TITLE
ffiwrapper: Close the correct end of the pipe in unseal

### DIFF
--- a/ffiwrapper/sealer_cgo.go
+++ b/ffiwrapper/sealer_cgo.go
@@ -329,7 +329,7 @@ func (sb *Sealer) UnsealPiece(ctx context.Context, sector abi.SectorID, offset s
 			uint64(at.Unpadded()),
 			uint64(abi.PaddedPieceSize(piece.Len).Unpadded()))
 
-		_ = opr.Close()
+		_ = opw.Close()
 
 		if err != nil {
 			return xerrors.Errorf("unseal range: %w", err)


### PR DESCRIPTION
(This "worked" enough of the time to not get noticed)