### PR TITLE
finalize not sched on unsealed worker

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -402,7 +402,7 @@ func (m *Manager) FinalizeSector(ctx context.Context, sector abi.SectorID) error
 		}
 	}
 
-	selector, err := newExistingSelector(ctx, m.index, sector, stores.FTCache|stores.FTSealed|unsealed, false)
+	selector, err := newExistingSelector(ctx, m.index, sector, stores.FTCache|stores.FTSealed, false)
 	if err != nil {
 		return xerrors.Errorf("creating path selector: %w", err)
 	}


### PR DESCRIPTION
finalize should not sched on unsealed worker, because that may be tansfer cache and sealed data