### PR TITLE
add RPC timeout to maybeSchedRequest (selector Cmp)

### DIFF
--- a/sched.go
+++ b/sched.go
@@ -240,7 +240,9 @@ func (sh *scheduler) maybeSchedRequest(req *workerRequest) (bool, error) {
 			var serr error
 
 			sort.SliceStable(acceptable, func(i, j int) bool {
-				r, err := req.sel.Cmp(req.ctx, req.taskType, sh.workers[acceptable[i]], sh.workers[acceptable[j]])
+				rpcCtx, cancel := context.WithTimeout(req.ctx, 5*time.Second)
+				r, err := req.sel.Cmp(rpcCtx, req.taskType, sh.workers[acceptable[i]], sh.workers[acceptable[j]])
+				cancel()
 				if err != nil {
 					serr = multierror.Append(serr, err)
 				}


### PR DESCRIPTION
oops, amendment to: https://github.com/filecoin-project/sector-storage/pull/54

Both selector.{Cmp, Ok} call RPC, and need to add timeout.