### PR TITLE
Modity addCachePathsForSectorSize func to support 2KiB sector size devnet locally also

### DIFF
--- a/faults.go
+++ b/faults.go
@@ -98,9 +98,11 @@ func addCachePathsForSectorSize(chk map[string]int64, cacheDir string, ssize abi
 	case 512 << 20:
 		chk[filepath.Join(cacheDir, "sc-02-data-tree-r-last.dat")] = 0
 	case 32 << 30:
-		fallthrough
-	case 64 << 30:
 		for i := 0; i < 8; i++ {
+			chk[filepath.Join(cacheDir, fmt.Sprintf("sc-02-data-tree-r-last-%d.dat", i))] = 0
+		}
+	case 64 << 30:
+		for i := 0; i < 16; i++ {
 			chk[filepath.Join(cacheDir, fmt.Sprintf("sc-02-data-tree-r-last-%d.dat", i))] = 0
 		}
 	default:

--- a/faults.go
+++ b/faults.go
@@ -91,9 +91,15 @@ func (m *Manager) CheckProvable(ctx context.Context, spt abi.RegisteredSealProof
 
 func addCachePathsForSectorSize(chk map[string]int64, cacheDir string, ssize abi.SectorSize) {
 	switch ssize {
+	case 2 << 10:
+		fallthrough
+	case 8 << 20:
+		fallthrough
 	case 512 << 20:
 		chk[filepath.Join(cacheDir, "sc-02-data-tree-r-last.dat")] = 0
 	case 32 << 30:
+		fallthrough
+	case 64 << 30:
 		for i := 0; i < 8; i++ {
 			chk[filepath.Join(cacheDir, fmt.Sprintf("sc-02-data-tree-r-last-%d.dat", i))] = 0
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23360623/86565698-ecfb9180-bf9a-11ea-9cf5-6d9123976df1.png)
