### PR TITLE
Update local.go

### DIFF
--- a/stores/local.go
+++ b/stores/local.go
@@ -273,6 +273,7 @@ func (st *Local) AcquireSector(ctx context.Context, sid abi.SectorID, spt abi.Re
 
 			best = filepath.Join(p.local, fileType.String(), SectorName(sid))
 			bestID = si.ID
+			break
 		}
 
 		if best == "" {


### PR DESCRIPTION
StorageBestAlloc returns a sorted slice of storage paths. if no break, It would alloc the worst-last path but not the first-best path.