### PR TITLE
remote: Fetch storage reservation

### DIFF
--- a/fsutil/filesize_unix.go
+++ b/fsutil/filesize_unix.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	"os"
 	"syscall"
 
 	"golang.org/x/xerrors"
@@ -14,12 +15,15 @@ type SizeInfo struct {
 func FileSize(path string) (SizeInfo, error) {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {
+		if err == syscall.ENOENT {
+			return SizeInfo{}, os.ErrNotExist
+		}
 		return SizeInfo{}, xerrors.Errorf("stat: %w", err)
 	}
 
 	// NOTE: stat.Blocks is in 512B blocks, NOT in stat.Blksize
 	//  See https://www.gnu.org/software/libc/manual/html_node/Attribute-Meanings.html
 	return SizeInfo{
-		int64(stat.Blocks) * 512,
+		int64(stat.Blocks) * 512, // NOTE: int64 cast is needed on osx
 	}, nil
 }

--- a/selector_existing.go
+++ b/selector_existing.go
@@ -12,17 +12,17 @@ import (
 )
 
 type existingSelector struct {
-	index stores.SectorIndex
-	sector abi.SectorID
-	alloc stores.SectorFileType
+	index      stores.SectorIndex
+	sector     abi.SectorID
+	alloc      stores.SectorFileType
 	allowFetch bool
 }
 
 func newExistingSelector(index stores.SectorIndex, sector abi.SectorID, alloc stores.SectorFileType, allowFetch bool) *existingSelector {
 	return &existingSelector{
-		index: index,
-		sector: sector,
-		alloc: alloc,
+		index:      index,
+		sector:     sector,
+		alloc:      alloc,
 		allowFetch: allowFetch,
 	}
 }

--- a/stores/interface.go
+++ b/stores/interface.go
@@ -9,15 +9,15 @@ import (
 type PathType string
 
 const (
-	PathStorage = "storage"
-	PathSealing = "sealing"
+	PathStorage PathType = "storage"
+	PathSealing PathType = "sealing"
 )
 
 type AcquireMode string
 
 const (
-	AcquireMove = "move"
-	AcquireCopy = "copy"
+	AcquireMove AcquireMode = "move"
+	AcquireCopy AcquireMode = "copy"
 )
 
 type Store interface {


### PR DESCRIPTION
This should fix most out-of-space errors when sectors are moved between workers